### PR TITLE
Update asyncapi rules with updated AsyncAPI v2 URL.

### DIFF
--- a/docs/reference/asyncapi-rules.md
+++ b/docs/reference/asyncapi-rules.md
@@ -1,6 +1,6 @@
 # AsyncAPI Rules
 
-Spectral has a built-in "asyncapi" ruleset for the [AsyncAPI Specification](https://www.asyncapi.com/docs/specifications/v2.0.0).
+Spectral has a built-in "asyncapi" ruleset for the [AsyncAPI Specification](https://v2.asyncapi.com/docs/reference).
 
 In your ruleset file you can add `extends: "spectral:asyncapi"` and you'll get all of the following rules applied.
 


### PR DESCRIPTION
**Checklist**

- [ ] Tests added / updated
- [X] Docs added / updated

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No


**Screenshots**

**Before**:
![image](https://github.com/RafaelJCamara/spectral/assets/52082556/e3a7ee80-f69f-443e-b2f6-8292f41f255e)

**After**:
![image](https://github.com/RafaelJCamara/spectral/assets/52082556/80904610-ba9e-4fc7-ae40-299a53a7f1fb)


**Additional context**

When you go to the AsyncAPI rules, there's a link for the supported AsyncAPI specification version:
![image](https://github.com/RafaelJCamara/spectral/assets/52082556/7bf26eda-7888-449d-9485-271193dc23fd)

When you click the existing link, we get the 404 mentioned in the above screenshot.

With this PR, we get a new non-broken link.
